### PR TITLE
 Correct the faulty layout and CSS in the Footer component.

### DIFF
--- a/src/components/footer/footer.module.css
+++ b/src/components/footer/footer.module.css
@@ -29,12 +29,7 @@
   justify-content: space-between;
   align-items: center;
   width: 2.75rem;
-  width: 2.8125rem;
-}
-
-.footerNav a img {
-  width: 100%;
-  height: 100%;
+  height: 2.75rem;
 }
 
 .footerNav a:hover img {
@@ -55,6 +50,7 @@
 }
 
 .footerSection a {
+  margin-bottom: 15px;
   color: var(--color-text);
   text-decoration: none;
 }


### PR DESCRIPTION
## 1. Changes

- Modify duplicate width attributes.
- To resolve the issue of images being biased to one side, remove the size attribute from the images in footerNav.
- Add margin attribute values between the text.

## 2. Screenshot

- 수정된 이미지
<img width="1680" alt="image" src="https://github.com/Trophy198/rustplusplus-credential-page/assets/96409594/2048563b-0d59-4d9a-be2d-2a87ede63adc">


## 3. Issues

1. 
2. 

## 4. Plans
[]