### PR TITLE
add temporary solution for rust+ pairing system

### DIFF
--- a/src/components/mainHeader/mainHeader.tsx
+++ b/src/components/mainHeader/mainHeader.tsx
@@ -40,7 +40,7 @@ const MainHeader = () => {
                 {isLoggedIn ? (
                   <>
                     <Link className={styles.rustplusplusActionButton} href="/display">
-                      Credential Info
+                      Auth Info
                     </Link>
                     <button className={styles.rustplusplusActionButton} onClick={handleLogout}>
                       Log Out

--- a/src/pages/api/callback.ts
+++ b/src/pages/api/callback.ts
@@ -37,7 +37,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const expiryDate = new Date(header.exp * 1000);
 
     const config = {
-      fcm_credentials: fcmCredentials,
+      // fcm_credentials: fcmCredentials,
+      authToken: token,
       steamId: steamId,
       expire_date: header.exp,
       issued_date: header.iss,

--- a/src/pages/display/index.tsx
+++ b/src/pages/display/index.tsx
@@ -32,7 +32,7 @@ const Display: NextPage<DisplayProps> = ({ formattedCredentials, expire_date, er
       ) : (
         <>
           <header>
-            <h1 className={styles.pageTitle}>Credential Info</h1>
+            <h1 className={styles.pageTitle}>Auth Info</h1>
           </header>
           <section className={styles.credentialsContainer}>
             <pre className={styles.credentialsPre}>{formattedCredentials}</pre>

--- a/src/pages/display/index.tsx
+++ b/src/pages/display/index.tsx
@@ -1,8 +1,8 @@
 import { GetServerSideProps, NextPage } from 'next';
 import { parseCookies, destroyCookie } from 'nookies';
-import { formatCredentialsData } from '@/utils/formatCredentialsData';
 import styles from './display.module.css';
 import { formatTimeRemaining } from '@/utils/formatTimeRemaining';
+import { formatAuthTokenData } from '@/utils/formatAuthTokenData';
 
 interface DisplayProps {
   formattedCredentials?: string;
@@ -78,7 +78,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 
   try {
     const credentials = JSON.parse(decodeURIComponent(config));
-    const { formattedData, expire_date } = formatCredentialsData(credentials);
+    const { formattedData, expire_date } = formatAuthTokenData(credentials);
     return {
       props: { formattedCredentials: formattedData, expire_date, error: null },
     };

--- a/src/utils/formatAuthTokenData.ts
+++ b/src/utils/formatAuthTokenData.ts
@@ -1,0 +1,19 @@
+interface AuthData {
+  authToken: string;
+  steamId: string;
+  issued_date: string;
+  expire_date: string;
+}
+
+export function formatAuthTokenData(AuthData: AuthData) {
+  const { authToken, steamId, expire_date, issued_date } = AuthData;
+
+  const formattedData =
+    `/authtoken add ` +
+    `token:${authToken} ` +
+    `steam_id:${steamId} ` +
+    `issued_date:${issued_date} ` +
+    `expire_date:${expire_date} `;
+
+  return { formattedData, expire_date };
+}


### PR DESCRIPTION
## 1. Changes

- Due to an issue with the Rust+ pairing system, we have provided a temporary solution. Instead of using the existing credential method, the pairing system has been temporarily modified to allow access using the user's authToken.

## 2. Screenshot

![스크린샷 2024-09-08 오후 3 49 22](https://github.com/user-attachments/assets/eeeb06a9-e018-494f-a620-b7b594ee142c)


## 3. Issues

#66 